### PR TITLE
Feature/Send Storage Regions [PLAT-685]

### DIFF
--- a/addons/osfstorage/models.py
+++ b/addons/osfstorage/models.py
@@ -502,18 +502,18 @@ class NodeSettings(BaseNodeSettings, BaseStorageAddon):
         return clone, None
 
     def serialize_waterbutler_settings(self):
-        return dict(settings.WATERBUTLER_SETTINGS, **{
+        return dict(Region.objects.get(id=self.region_id).waterbutler_settings, **{
             'nid': self.owner._id,
             'rootId': self.root_node._id,
             'baseUrl': self.owner.api_url_for(
                 'osfstorage_get_metadata',
                 _absolute=True,
                 _internal=True
-            )
+            ),
         })
 
     def serialize_waterbutler_credentials(self):
-        return settings.WATERBUTLER_CREDENTIALS
+        return Region.objects.get(id=self.region_id).waterbutler_credentials
 
     def create_waterbutler_log(self, auth, action, metadata):
         params = {


### PR DESCRIPTION
❗️ Depends on https://github.com/CenterForOpenScience/osf.io/pull/8218, must be merged first

## Purpose

Send saved storage region to WB as part of stored auth request.
## Changes

<!-- Briefly describe or list your changes  -->
Pulling waterbutler_settings and waterbutler_credentials off of associated Region object, rather than settings. 


## QA Notes

<!-- Does this change need QA? If so, this section is required.
     - Is cross-browser testing required/recommended?
     - Is API testing required/recommended?
     - What pages on the OSF should be tested?
     - What edge cases should QA be aware of?
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket


https://openscience.atlassian.net/browse/PLAT-685