### PR TITLE
Remove target.reload() from metadata serialization

### DIFF
--- a/osf/metadata/serializers.py
+++ b/osf/metadata/serializers.py
@@ -40,7 +40,6 @@ class DataciteMetadataRecordSerializer(MetadataRecordSerializer):
     def serialize_json(cls, record):
         osfstorage_file = record.file
         target = osfstorage_file.target
-        target.reload()
         doc = {
             'creators': utils.datacite_format_contributors(target.visible_contributors),
             'titles': [

--- a/osf_tests/test_file_metadata.py
+++ b/osf_tests/test_file_metadata.py
@@ -64,9 +64,12 @@ class TestFileMetadataRecordSerializer:
             'year': '2018',
             'copyrightHolders': ['Woop', 'Yeah']
         }
+
         set_license(node, license_detail, Auth(node.creator))
+
         osf_file.save()
         node.save()
+        osf_file.target.reload()
 
         record = osf_file.records.get(schema___id='datacite')
         serialized_record = json.loads(record.serialize())


### PR DESCRIPTION
#### Purpose / Changes
* Remove `target.reload()` from metadata serialization. 
* Reload `osf_file.target` in the test (after `node.save()`) 

#### Ticket 
https://openscience.atlassian.net/browse/OSF-1128
