### PR TITLE
[No Ticket] When version is None default to latest version

### DIFF
--- a/addons/base/views.py
+++ b/addons/base/views.py
@@ -280,18 +280,21 @@ def get_auth(auth, **kwargs):
 
     if path and auth.user:
         mark_file_version_as_seen(auth.user, path, version)
-    if path and version:
+
+    if path:
         if not node.is_contributor(auth.user):
             download_is_from_mfr = request.headers.get('X-Cos-Mfr-Render-Request', None)
             file_id = path.strip('/')
+
+            # When no version is provided we default to the most recent indexed at 0
+            version_num = version if version is not None else OsfStorageFile.objects.get(_id=file_id).versions.count() - 1
+
             if action == 'render':
-                update_analytics(node, file_id, version, 'view')
+                update_analytics(node, file_id, version_num, 'view')
             elif action == 'download' and not download_is_from_mfr:
-                update_analytics(node, file_id, version, 'download')
+                update_analytics(node, file_id, version_num, 'download')
 
     try:
-        path = data.get('path')
-        version = data.get('version')
         credentials = None
         waterbutler_settings = None
         fileversion = None


### PR DESCRIPTION
## Purpose

This addresses an issue @sloria  brought up when commenting on this PR. https://github.com/CenterForOpenScience/osf.io/pull/8496#pullrequestreview-165349553

## Changes

Grabs highest version number representing most recent verison when no version is provided. 
